### PR TITLE
Use prod plan-only infrastructure library

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,5 +1,5 @@
 #!groovy
-@Library('Infrastructure@allow-plan-only')
+@Library('Infrastructure@ccd-es-prod-plan-only')
 
 import uk.gov.hmcts.contino.Environment
 import uk.gov.hmcts.contino.HealthChecker

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -98,8 +98,7 @@ withInfraPipeline(params.PRODUCT_NAME, null, !params.DEPLOY_ES_CLUSTER) {
         healthCheckStage('nonprod', 'aat')
     }
     afterAlways('buildinfra:prod') {
-        echo 'Healthcheck in PROD'
-        healthCheckStage('prod', 'prod')
+        echo 'Skipping PROD healthcheck: prod infrastructure is plan-only with Infrastructure@ccd-es-prod-plan-only'
     }
     afterAlways('buildinfra:perftest') {
         echo 'Healthcheck in Perftest'


### PR DESCRIPTION
## What

Updates `Jenkinsfile_CNP` to consume the temporary `cnp-jenkins-library` branch `ccd-es-prod-plan-only`.

## Why

This allows the intended master build path for `ccd-elastic-search` to be reviewed while ensuring the prod infrastructure stage only performs Terraform plan and does not apply.

## Additional safety

The PROD healthcheck callback now logs that it is skipped, because the prod infrastructure stage is intentionally plan-only and no prod apply has happened.

## Dependency

Depends on hmcts/cnp-jenkins-library#1440.